### PR TITLE
docs: fix simple typo, resoltion -> resolution

### DIFF
--- a/pywebshot.py
+++ b/pywebshot.py
@@ -18,7 +18,7 @@ class PyWebShot:
 		self.urls = urls
 		self.delay = delay
 
-		# Get resoltion information
+		# Get resolution information
 		(x,y) = screen.split('x')
 		x = int(x)
 		y = int(y)


### PR DESCRIPTION
There is a small typo in pywebshot.py.

Should read `resolution` rather than `resoltion`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md